### PR TITLE
Fixed bug where arrays of objects would get infinitely extended.

### DIFF
--- a/core/Core.js
+++ b/core/Core.js
@@ -210,7 +210,8 @@ AjaxSolr.extend = function () {
         if (target === copy) {
           continue;
         }
-        if (copy && typeof copy == 'object' && !copy.nodeType) {
+        var copy_is_array = toString.call(copy) === '[object Array]';
+        if (copy && typeof copy == 'object' && !copy.nodeType && !copy_is_array) {
           target[name] = AjaxSolr.extend(src || (copy.length != null ? [] : {}), copy);
         }
         else if (copy && src && typeof copy == 'function' && typeof src == 'function') {


### PR DESCRIPTION
When you create a new instance of an object based on AjaxSolr.Class,
and set one of the parameters to an array of objects, this code would
iterate through each one of those objects and extend it.

This fix avoids calling extend if the array is actually an array
object.

Tested and works with gh-pages, and my own code that was previously
broken because of this bug.
