### PR TITLE
Escape forward slashes

### DIFF
--- a/core/Parameter.js
+++ b/core/Parameter.js
@@ -170,9 +170,9 @@ AjaxSolr.Parameter = AjaxSolr.Class.extend(
  * @returns {String} The escaped value.
  */
 AjaxSolr.Parameter.escapeValue = function (value) {
-  // If the field value has a space or a colon in it, wrap it in quotes,
+  // If the field value has a space, colon or forward slash in it, wrap it in quotes,
   // unless it is a range query or it is already wrapped in quotes.
-  if (value.match(/[ :]/) && !value.match(/[\[\{]\S+ TO \S+[\]\}]/) && !value.match(/^["\(].*["\)]$/)) {
+  if (value.match(/[ :\/]/) && !value.match(/[\[\{]\S+ TO \S+[\]\}]/) && !value.match(/^["\(].*["\)]$/)) {
     return '"' + value + '"';
   }
   return value;


### PR DESCRIPTION
In Solr 4.0, you can use regular expressions in queries by delimiting them using slashes. This means that any parameters that contain a forward slash need to be surrounded in quotes (or escaped).

See https://issues.apache.org/jira/browse/LUCENE-2604
